### PR TITLE
Allow Marathon URL to have a path

### DIFF
--- a/lib/marathon.js
+++ b/lib/marathon.js
@@ -23,7 +23,7 @@ function Marathon(url, opts) {
             path = (skipVersion ? '/' : '/v2/') + path;
             options.method = method;
             options.qs = query;
-            options.url = nodeUrl.resolve(options.url, path);
+            options.url = options.url + path;
             if (addOptions) {
                 options = _.extend(options, addOptions);
             }

--- a/spec/marathon.spec.js
+++ b/spec/marathon.spec.js
@@ -79,3 +79,26 @@ describe('marathon', function() {
 
 
 });
+
+describe('config', function() {
+    var Marathon = require('../lib/marathon.js');
+    var nock = require('nock');
+
+    it('should allow marathon urls with paths', function (done) {
+      var MARATHON_HOST='http://01.02.03.04:5678';
+      var pathedUrl = MARATHON_HOST + '/service/marathon';
+
+      var scope = nock(MARATHON_HOST)
+          .get('/service/marathon/ping')
+          .reply(200, 'pong');
+
+      var marathon = new Marathon(pathedUrl);
+      marathon.misc.ping().then(onSuccess).done();
+
+      function onSuccess(data) {
+          expect(data).toEqual('pong');
+          expect(scope.isDone()).toEqual(true);
+          done();
+      }
+    });
+});


### PR DESCRIPTION
Allow Marathon URL to have a path, not just a host.  For instance, in a
default Mesosphere setup, marathon is at http://<host>/services/marathon
.  Without this fix, marathon-node won't work because it looks for
(e.g.) http://<host>/v2/ping  instead of
http://<host>/service/marathon/v2/ping .