### PR TITLE
Complementing support to /v2/events

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,39 @@ const opts = {
 ***Other options:***
 - `logTime` - if `true`, logs requests time to console
 
+## Marathon Event Bus
+
+When we attach to the [Marathon Event Bus](https://mesosphere.github.io/marathon/docs/event-bus.html) (from the Nodejs perspective) we receive a [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams) object.
+
+***Attaching to Event Bus example:***
+
+```javascript
+const marathon = require('marathon-node')(MARATHON_URL, opts);
+
+marathon.events.attach()
+	.then(function(stream) {
+		// Forces the stream to receive a String instead of a Buffer object
+		stream.setEncoding('utf-8');
+
+		// Event that receives data from Marathon
+		stream.on('data', function(chunk) {
+			// Printing the event received from the stream
+			console.log(chunk);
+		});
+
+		// Last event, it runs when the connection is closed
+		stream.on('end', function() {
+			// Here you do what you need when it ends...
+		});
+
+		// If for some reason we receive an error while connected, we can handle it here
+		stream.on('errror', function(err) {
+			// Error handling...
+		})
+	}).catch(function(err) {
+		// Any problem while trying to connect to /v2/events
+	});
+```
 
 ## Methods
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -2,7 +2,7 @@ module.exports = function createMethods(makeRequest) {
     return {
         // /v2/events
         attach: function attach() {
-            return makeRequest('GET', '/events')();
+            return makeRequest('GET', '/events', {headers: {Accept: 'text/event-stream'}}, true)();
         }
     };
 };

--- a/lib/marathon.js
+++ b/lib/marathon.js
@@ -1,4 +1,5 @@
 var rp = require('request-promise');
+var request = require('request');
 var _ = require('lodash');
 
 var API_VERSION = 'v2';
@@ -32,7 +33,7 @@ function Marathon(url, opts) {
 
     _.assign(baseOptions, _.omit(opts, 'logTime'));
 
-    function makeRequest(method, path, addOptions) {
+    function makeRequest(method, path, addOptions, requestStream) {
         return function closure(query, body) {
             var requestOptions = _.cloneDeep(baseOptions);
 
@@ -60,6 +61,21 @@ function Marathon(url, opts) {
                 if (opts.logTime) {
                     console.timeEnd(consoleTimeToken);
                 }
+            }
+
+            if (requestStream) {
+                return new Promise((resolve, reject) => {
+                        request[method.toLocaleLowerCase()](requestOptions)
+                            .on('error', (err) => {
+                                return reject(err);
+                            })
+                            .on('response', (readableStream) => {
+                                readableStream.on('end', () => {
+                                    logTime();
+                                });
+                                return resolve(readableStream);
+                            });
+                    });
             }
 
             return rp(requestOptions)

--- a/lib/marathon.js
+++ b/lib/marathon.js
@@ -64,7 +64,7 @@ function Marathon(url, opts) {
             }
 
             if (requestStream) {
-                return new Promise((resolve, reject) => {
+                return new Promise(function(resolve, reject) {
                         request[method.toLocaleLowerCase()](requestOptions)
                             .on('error', (err) => {
                                 return reject(err);

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -14,18 +14,17 @@ describe('events', function() {
 
     describe('#attach()', function() {
         it('should attach to the event stream', function() {
-            var response = {};
-
             var scope = nock(MARATHON_HOST)
+                .matchHeader('Accept', 'text/event-stream')
                 .get('/v2/events')
-                .reply(200, response);
+                .reply(200);
 
-            return marathon.events.attach().then(onSuccess);
-
-            function onSuccess(data) {
-                expect(data).to.deep.equal(response);
+            function onSuccess(stream) {
+                expect(stream.statusCode).to.equal(200);
                 expect(scope.isDone()).to.be.true;
             }
+
+            return marathon.events.attach().then(onSuccess);
         });
     });
 });


### PR DESCRIPTION
First of all, thanks for this amazing lib and work!

This pull request adds a required header for the `/v2/events` endpoint, which needs the `Accept: text/event-stream` to connect (following the Marathon API Documentation).

Not only that, but since `request-promise` currently has problems resolving promises with streams (check https://github.com/request/request-promise/issues/90)
and even their documentation states that we must use the `request` lib to resolve those ones, I made a small change to be able to resolve this promise and return the stream to be managed by the user following his needs.