### PR TITLE
Proposed change to make the CI work with Promises

### DIFF
--- a/lib/marathon.js
+++ b/lib/marathon.js
@@ -1,5 +1,6 @@
 var rp = require('request-promise');
 var request = require('request');
+var Promise = require('bluebird');
 var _ = require('lodash');
 
 var API_VERSION = 'v2';

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   },
   "homepage": "https://github.com/elasticio/marathon-node",
   "dependencies": {
+    "bluebird": "^3.4.7",
     "lodash": "^4.0.0",
     "request-promise": "^3.0.0",
     "request": "2.75.x"
   },
   "devDependencies": {
-    "bluebird": "^3.4.7",
     "chai": "^3.5.0",
     "code-quality-js": "^1.1.1",
     "jscs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "request": "2.75.x"
   },
   "devDependencies": {
+    "bluebird": "^3.4.7",
     "chai": "^3.5.0",
     "code-quality-js": "^1.1.1",
     "jscs": "^3.0.3",


### PR DESCRIPTION
@pnedelko ,

After merging this [PR](https://github.com/elasticio/marathon-node/pull/12), I noticed that the CI started to fail. Looks like the Promises that I was using are not supported by the CI.

So I am opening this PR to propose a small change. It would use [Bluebird](https://github.com/petkaantonov/bluebird) Promises, and would solve the issue with the CI. The implementation is exactly the same as the native Promises, so no change on code or tests.

What do you think about this?