### PR TITLE
updated to use querystring for create/delete eventSubscriptions

### DIFF
--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -3,10 +3,10 @@ module.exports = function createMethods(makeRequest) {
         // /v2/eventSubscriptions
         getList: makeRequest('GET', '/eventSubscriptions'),
         create: function create(callbackUrl) {
-            return makeRequest('POST', '/eventSubscriptions')({callbackUrl: callbackUrl});
+            return makeRequest('POST', '/eventSubscriptions')({qs: "callbackUrl=" + callbackUrl});
         },
         delete: function deleteSubscription(callbackUrl) {
-            return makeRequest('DELETE', '/eventSubscriptions')({callbackUrl: callbackUrl});
+            return makeRequest('DELETE', '/eventSubscriptions')({qs: "callbackUrl=" + callbackUrl});
         }
     };
 };


### PR DESCRIPTION
query string parsing seems not be working as expected. Explicit definition of the qs parameter appears to address this issue for me