### PR TITLE
make embed work with array and with groups

### DIFF
--- a/lib/groups.js
+++ b/lib/groups.js
@@ -1,21 +1,21 @@
 module.exports = function createMethods(makeRequest) {
     return {
         // /v2/groups
-        getList: function getList() {
-            return makeRequest('GET', '/groups')();
+        getList: function getList(query) {
+            return makeRequest('GET', '/groups')(query);
         },
         create: function create(body) {
             return makeRequest('POST', '/groups')(null, body);
         },
         // /v2/groups/{group_id}
-        getOne: function getOne(groupId) {
-            return makeRequest('GET', '/groups/' + groupId)();
+        getOne: function getOne(groupId, query) {
+            return makeRequest('GET', '/groups/' + groupId)(query);
         },
         update: function update(groupId, body, force) {
-            return makeRequest('PUT', '/groups/' + groupId)({force: force}, body);
+            return makeRequest('PUT', '/groups/' + groupId)({ force: force }, body);
         },
         destroy: function destroy(groupId, force) {
-            return makeRequest('DELETE', '/groups/' + groupId)({force: force});
+            return makeRequest('DELETE', '/groups/' + groupId)({ force: force });
         }
     };
 };

--- a/lib/marathon.js
+++ b/lib/marathon.js
@@ -51,6 +51,7 @@ function Marathon(baseUrl, opts) {
             requestOptions.method = method;
             requestOptions.qs = query;
             requestOptions.url = nodeUrl.format(getRequestUrl(path));
+            requestOptions.qsStringifyOptions = { arrayFormat: "repeat" };
 
             if (addOptions) {
                 requestOptions = _.extend(requestOptions, addOptions);


### PR DESCRIPTION
Currently, it's not possible to pass multiple parameters to the embed part of the query. This means a lot of things don't work. In addition, the groups API didn't have the same option to pass the embed parameter like the apps API does. This fixes that.